### PR TITLE
Fix twitter demo

### DIFF
--- a/ext/qml/qml.c
+++ b/ext/qml/qml.c
@@ -68,11 +68,17 @@ static VALUE qml_engine(VALUE module) {
     return rbqml_engine;
 }
 
-static void nextTickCallback(void *data)
+static void *nextTickCallbackImpl(void *data)
 {
     VALUE block = (VALUE)data;
     rb_proc_call(block, rb_ary_new());
     rb_hash_delete(rbqml_referenced_objects, block);
+    return NULL;
+}
+
+static void nextTickCallback(void *data)
+{
+    rb_thread_call_with_gvl(nextTickCallbackImpl, data);
 }
 
 static VALUE qml_next_tick(int argc, VALUE *argv, VALUE module) {


### PR DESCRIPTION
Fix #24 (Twitter demo)

* [Fix libqmlbind](https://github.com/seanchas116/libqmlbind/commit/1bea43bb99b88f3f4332b05a45de7b6582a68013)
* Use GVL on next_tick callback